### PR TITLE
Fix oddly camel cased GitHub URL

### DIFF
--- a/book/01-introduction/sections/01-why-atom.asc
+++ b/book/01-introduction/sections/01-why-atom.asc
@@ -40,4 +40,4 @@ With the entire industry pushing web technology forward, we're confident that we
 
 We see Atom as a perfect complement to GitHub's primary mission of building better software by working together. Atom is a long-term investment, and GitHub will continue to support its development with a dedicated team going forward. But we also know that we can't achieve our vision for Atom alone. As Emacs and Vim have demonstrated over the past three decades, if you want to build a thriving, long-lasting community around a text editor, it has to be open source.
 
-The entire Atom editor is free and open source and is available under the https://gitHub.com/atom organization.
+The entire Atom editor is free and open source and is available under the https://github.com/atom organization.


### PR DESCRIPTION
Noticed this while reading the docs, and seems to the only link formatted this way.