### PR TITLE
Fix activationEvents -> activationCommands

### DIFF
--- a/book/03-hacking-atom/sections/02-a-basic-package.asc
+++ b/book/03-hacking-atom/sections/02-a-basic-package.asc
@@ -51,7 +51,7 @@ key mappings your package needs to load. If not specified, mappings in the _keym
 - `snippets`: an Array of Strings identifying the order of the
 snippets your package needs to load. If not specified, snippets in the _snippets_ directory are added alphabetically.
 
-- `activationEvents`: an Array of Strings identifying events that trigger your package's activation. You can delay the loading of your package until one of these events is triggered.
+- `activationCommands`: an Array of Strings identifying events that trigger your package's activation. You can delay the loading of your package until one of these events is triggered.
 
 The `package.json` in the package we've just generated looks like this currently:
 

--- a/book/03-hacking-atom/sections/02-a-basic-package.asc
+++ b/book/03-hacking-atom/sections/02-a-basic-package.asc
@@ -51,7 +51,8 @@ key mappings your package needs to load. If not specified, mappings in the _keym
 - `snippets`: an Array of Strings identifying the order of the
 snippets your package needs to load. If not specified, snippets in the _snippets_ directory are added alphabetically.
 
-- `activationCommands`: an Array of Strings identifying events that trigger your package's activation. You can delay the loading of your package until one of these events is triggered.
+- `activationCommands`: an Object identifying commands that trigger your package's activation. The keys are CSS selectors, the values are Arrays of Strings identifying the command.
+The loading of your package is delayed until one of these events is triggered within the associated scope defined by the CSS selector.
 
 The `package.json` in the package we've just generated looks like this currently:
 


### PR DESCRIPTION
Change `activationEvents` to `activationCommands` and update the description to match current behavior.