### PR TITLE
Update guide for ascii-art package

### DIFF
--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -19,7 +19,7 @@ The final package can be viewed at https://github.com/atom/ascii-art.
 
 To begin, press `cmd-shift-P` to bring up the https://github.com/atom/command-palette[Command
 Palette]. Type "generate package" and
-select the "Package Generator: Generate Package" command, just as we did in <<_generate_package>>.
+select the "Package Generator: Generate Package" command, just as we did in <<_generate_package>>. Enter `ascii-art` as the name of the package.
 
 Now let's edit the package files to make our ASCII Art package do something interesting. Since this package doesn't need any UI, we can remove all view-related code so go ahead and delete `lib/ascii-art-view.coffee`, `spec/ascii-art-view-spec.coffee`, and `styles/`.
 

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -3,13 +3,12 @@
 Now that we have our first package written, let's go through examples of other types of packages we can make. This section will guide you though creating a simple command that replaces the selected text with https://en.wikipedia.org/wiki/ASCII_art[ascii art]. When you run our new command with the word "cool" selected, it will be replaced with:
 
 ```
-                     ___
-                    /\_ \
-  ___    ___     ___\//\ \
- /'___\ / __`\  / __`\\ \ \
-/\ \__//\ \L\ \/\ \L\ \\_\ \_
-\ \____\ \____/\ \____//\____\
- \/____/\/___/  \/___/ \/____/
+                                     o888
+    ooooooo     ooooooo     ooooooo   888
+  888     888 888     888 888     888 888
+  888         888     888 888     888 888
+    88ooo888    88ooo88     88ooo88  o888o
+
 ```
 
 This should demonstrate how to do basic text manipulation in the current text buffer and how to deal with selections.
@@ -111,7 +110,7 @@ convert: ->
     selection = editor.getSelectedText()
 
     figlet = require 'figlet'
-    font = "Larry 3D 2"
+    font = "o8"
     figlet selection, {font: font}, (error, art) ->
       if error
         console.error(error)

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -33,9 +33,8 @@ module.exports =
 
   activate: ->
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.commands.add
-                        'atom-workspace',
-                          'ascii-art:convert': => @convert()
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'ascii-art:convert': => @convert()
 
   deactivate: ->
     @subscriptions.dispose()

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -61,11 +61,11 @@ Next we insert a string into the current text editor with the https://atom.io/do
 
 ===== Reload the Package
 
-Before we can trigger `ascii-art:convert`, we need to load the latest code for our package by reloading the window. Run the command `window:reload` from the command palette or by pressing `ctrl-alt-cmd-l`.
+Before we can trigger `ascii-art:convert`, we need to load the latest code for our package by reloading the window. Run the command "Window: Reload" from the command palette or by pressing `ctrl-alt-cmd-l`.
 
 ===== Trigger the Command
 
-Now open the command panel and search for the `ascii-art:convert` command. But it's not there! To fix this, open _package.json_ and find the property called `activationCommands`. Activation Events speed up load time by allowing Atom to delay a package's activation until it's needed. So remove the existing command and add `ascii-art:convert` to the `activationCommands` array:
+Now open the command panel and search for the "Ascii Art: Convert" command. But it's not there! To fix this, open _package.json_ and find the property called `activationCommands`. Activation commands speed up load time by allowing Atom to delay a package's activation until it's needed. So remove the existing command and use `ascii-art:convert` in `activationCommands`:
 
 ```json
 "activationCommands": {
@@ -73,7 +73,7 @@ Now open the command panel and search for the `ascii-art:convert` command. But i
 }
 ```
 
-First, reload the window by running the command `window:reload`. Now when you run the `ascii-art:convert` command it will output 'Hello, World!'
+First, reload the window by running the command "Window: Reload" from the command palette. Now when you run the "Ascii Art: Convert" command it will output 'Hello, World!'
 
 ===== Add a Key Binding
 
@@ -98,8 +98,7 @@ Now we need to convert the selected text to ASCII art. To do this we will use th
 }
 ```
 
-After saving the file, run the command 'update-package-dependencies:update' from
-the Command Palette. This will install the package's node module dependencies, only figlet in this case. You will need to run 'update-package-dependencies:update' whenever you update the dependencies field in your _package.json_ file.
+After saving the file, run the command "Update Package Dependencies: Update" from the Command Palette. This will install the package's node module dependencies, only figlet in this case. You will need to run "Update Package Dependencies: Update" whenever you update the dependencies field in your _package.json_ file.
 
 If for some reason this doesn't work, you'll see a message saying ``Failed to update package dependencies'' and you will find a new `npm-debug.log` file in your directory. That file should give you some idea as to what went wrong.
 

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -92,7 +92,7 @@ Now we need to convert the selected text to ASCII art. To do this we will use th
 
 ```json
 "dependencies": {
-   "figlet": "1.0.8"
+  "figlet": "1.0.8"
 }
 ```
 

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -21,7 +21,7 @@ To begin, press `cmd-shift-P` to bring up the https://github.com/atom/command-pa
 Palette]. Type "generate package" and
 select the "Package Generator: Generate Package" command, just as we did in <<_generate_package>>.
 
-Now let's edit the package files to make our ASCII Art package do something interesting. Since this package doesn't need any UI, we can remove all view-related code so go ahead and delete `ascii-art-view.coffee`.
+Now let's edit the package files to make our ASCII Art package do something interesting. Since this package doesn't need any UI, we can remove all view-related code so go ahead and delete `lib/ascii-art-view.coffee`, `spec/ascii-art-view-spec.coffee`, and `styles/`.
 
 Next, open up `lib/ascii-art.coffee` and remove all view code, so it looks like this:
 

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -68,7 +68,9 @@ Before we can trigger `ascii-art:convert`, we need to load the latest code for o
 Now open the command panel and search for the `ascii-art:convert` command. But it's not there! To fix this, open _package.json_ and find the property called `activationCommands`. Activation Events speed up load time by allowing Atom to delay a package's activation until it's needed. So remove the existing command and add `ascii-art:convert` to the `activationCommands` array:
 
 ```json
-"activationCommands": ["ascii-art:convert"],
+"activationCommands": {
+  "atom-workspace": "ascii-art:convert"
+}
 ```
 
 First, reload the window by running the command `window:reload`. Now when you run the `ascii-art:convert` command it will output 'Hello, World!'

--- a/book/03-hacking-atom/sections/03-modify-buffer.asc
+++ b/book/03-hacking-atom/sections/03-modify-buffer.asc
@@ -28,7 +28,7 @@ Next, open up `lib/ascii-art.coffee` and remove all view code, so it looks like 
 ```coffeescript
 {CompositeDisposable} = require 'atom'
 
-module.exports = AsciiArt =
+module.exports =
   subscriptions: null
 
   activate: ->


### PR DESCRIPTION
This is part 2 of fixing https://github.com/atom/ascii-art/issues/2, you can see part 1 here: https://github.com/atom/ascii-art/pull/3.

There was a bunch of small things causing problems for users following the guide step-by-step, and the guide didn't match exactly what the package generator created and what the demo package in https://github.com/atom/ascii-art looked like. 

/cc @kiwitotoro @erikweibust @pbrianmackey who were discussing problems over in https://github.com/atom/ascii-art/issues/2. 