### PR TITLE
Fix a few links in the debugging guide

### DIFF
--- a/book/03-hacking-atom/sections/A01-debugging.asc
+++ b/book/03-hacking-atom/sections/A01-debugging.asc
@@ -49,8 +49,7 @@ TODO: Document TimeCop
 
 ==== Check the keybindings
 
-If a command is not executing when you hit a keystroke or the wrong command is executing, there might be an issue with the keybindings for that keystroke. Atom ships with the https://atom.io/packages/keybinding-resolver
-[Keybinding resolver], a neat package which helps you understand which keybindings are executed.
+If a command is not executing when you hit a keystroke or the wrong command is executing, there might be an issue with the keybindings for that keystroke. Atom ships with the https://atom.io/packages/keybinding-resolver[Keybinding resolver], a neat package which helps you understand which keybindings are executed.
 
 Show the keybinding resolver with `cmd-.` or with ``Key Binding Resolver: Show'' from the Command palette. With the keybinding resolver shown, hit a keystroke:
 
@@ -70,8 +69,7 @@ If multiple keybindings are matched, Atom determines which keybinding will be ex
 * the keystroke was not used in the context defined by the keybinding's selector. For example, you can't trigger the ``Tree View: Add File'' command if the Tree View is not focused, or
 * there is another keybinding that took precedence. This often happens when you install a package which defines keybinding that conflict with existing keybindings. If the package's keybindings have selectors with higher specificity or were loaded later, they'll have priority over existing ones.
 
-Atom loads core Atom keybindings and package keybindings first, and user-defined keybindings after last. Since user-defined keybindings are loaded last, you can use your `keymap.cson` file to tweak the keybindings and sort out problems like these. For example, you can remove keybindings with https://atom.io/docs/latest/advanced/keymaps#removing-bindings
-[the `unset!` directive].
+Atom loads core Atom keybindings and package keybindings first, and user-defined keybindings after last. Since user-defined keybindings are loaded last, you can use your `keymap.cson` file to tweak the keybindings and sort out problems like these. For example, you can remove keybindings with https://atom.io/docs/latest/behind-atom-keymaps-in-depth#removing-bindings[the `unset!` directive].
 
 If you notice that a package's keybindings are taking precedence over core Atom keybindings, it might be a good idea to report the issue on the package's GitHub repository.
 


### PR DESCRIPTION
Broken because there was a space between the URL and the text, and one link was pointing to the old docs site.