### PR TITLE
`ctrl-cmd` makes little sense. Split `ctrl` vs. `cmd`

### DIFF
--- a/book/02-using-atom/sections/02-text.asc
+++ b/book/02-using-atom/sections/02-text.asc
@@ -90,7 +90,7 @@ There are a handful of cool keybindings for basic text manipulation that might c
 
 `cmd-J`:: Join the next line to the end of the current line
 
-`ctrl-cmd-up`, `ctrl-cmd-down`:: Move the current line up or down
+`cmd-up`, `cmd-down` (`ctrl-up`, `ctrl-down`) :: Move the current line up or down
 
 `cmd-shift-D`:: Duplicate the current line
 


### PR DESCRIPTION
I recommend using just `cmd` everywhere. That seems to be what the rest of the manual is following. But if you want to mention both then perhaps this is the way to go. Let me know in either case :heart: 