### PR TITLE
invalid href to `atom/settings-view` at `01-packages-themes.asc`

### DIFF
--- a/book/02-using-atom/sections/01-packages-themes.asc
+++ b/book/02-using-atom/sections/01-packages-themes.asc
@@ -1,7 +1,7 @@
 [[_atom_packages]]
 === Atom Packages
 
-First we'll start with the Atom package system. As we mentioned previously, Atom itself is a very basic core of functionality that ships with a number of useful packages that add new features like the Tree view and the Settings view (which, by the way, can be found here: https://github.com/atom/settings-view).
+First we'll start with the Atom package system. As we mentioned previously, Atom itself is a very basic core of functionality that ships with a number of useful packages that add new features like the https://github.com/atom/tree-view[Tree View] and the https://github.com/atom/settings-view[Settings View].
 
 In fact, there are more than 70 packages that comprise all of the functionality that is available in Atom by default. As some examples, the https://github.com/atom/welcome[Welcome dialog] that you see when you first start it, the https://github.com/atom/spell-check[spell checker], the https://github.com/atom/atom-dark-ui[themes] and the https://github.com/atom/fuzzy-finder[fuzzy finder] are all packages that are separately maintained and all use the same APIs that you have access to, as we'll see in great detail in <<_hacking_atom>>.
 


### PR DESCRIPTION
The parenthesis was being included in the link.