### PR TITLE
updated semver summary, closes #29

### DIFF
--- a/book/03-hacking-atom/sections/02-a-basic-package.asc
+++ b/book/03-hacking-atom/sections/02-a-basic-package.asc
@@ -467,7 +467,7 @@ The `minor` option to the publish command tells apm to increment the second digi
 
 The `patch` option to the publish command tells apm to increment the third digit of the version before publishing so the published version will be `0.0.1` and the Git tag created will be `v0.0.1`.
 
-Use `major` when you make a huge change, like a rewrite, or a large change to the functionality or interface. Use `minor` when adding or removing a feature. Use `patch` when you make a small change like a bug fix that does not add or remove features.
+Use `major` when you make a change that breaks backwards compatibility, like changing defaults or removing features. Use `minor` when adding new functionality or making improvements on existing code. Use `patch` when you fix a bug that was causing incorrect behaviour.
 
 Check out http://semver.org[semantic versioning] to learn more about versioning your package releases.
 


### PR DESCRIPTION
Old description/summary mentioned that you should use `minor` when removing a feature, and that's incorrect.