### PR TITLE
Clarification for invisible characters

### DIFF
--- a/book/02-using-atom/sections/06-customizing.asc
+++ b/book/02-using-atom/sections/06-customizing.asc
@@ -84,7 +84,7 @@ You can open this file in an editor from the _Atom > Open Your Config_ menu.
 ** `nonWordCharacters`: A string of non-word characters to define word boundaries
 ** `fontSize`: The editor font size
 ** `fontFamily`: The editor font family
-** `invisibles`: Specify characters that Atom renders for invisibles in this hash
+** `invisibles`: Specify characters that Atom renders for invisibles in this hash (use `false` to turn off individual character types)
 *** `tab`: Hard tab characters
 *** `cr`: Carriage return (for Microsoft-style line endings)
 *** `eol`: `\n` characters


### PR DESCRIPTION
Added a note stating that individual invisible character types can be turned off with a boolean `false` (per the config schema).

The only other option to disable individual characters is to set them to an empty string (`''`), however due to a bug with handling the empty default values, configuration for `invisibles` will be [reset every time the Settings tab is opened](https://github.com/atom/settings-view/issues/237)!

It's best to mention that the "correct" way for disabling certain invisibles is with a boolean.