### PR TITLE
Add 'other' back to title

### DIFF
--- a/book/04-behind-atom/sections/06-services-api.asc
+++ b/book/04-behind-atom/sections/06-services-api.asc
@@ -1,4 +1,4 @@
-=== Interacting With Packages Via Services
+=== Interacting With Other Packages Via Services
 
 Atom packages can interact with each other through versioned APIs called _services_. To provide a service, in your `package.json`, specify one or more version numbers, each paired with the name of a method on your package's main module:
 


### PR DESCRIPTION
Editing the title of the Services API section. 