### PR TITLE
Update references to atom-shell to Electron

### DIFF
--- a/outline.txt
+++ b/outline.txt
@@ -115,9 +115,9 @@ Here is the remaining outline:
 
 # Chapter 6
 
-* Atom Shell
-  * developing a new project in atom shell
-  * https://github.com/atom/husk
+* Electron
+  * developing a new project in electron
+  * https://github.com/atom/electron
 
 # Chapter 7 / Appendix
 


### PR DESCRIPTION
I'm not sure if the `outline.txt` is the plan-of-record anymore, but I figured this should be updated if it was still being used to record ideas.