### PR TITLE
Add docs on setting up a proxy

### DIFF
--- a/book/01-introduction/sections/02-installing.asc
+++ b/book/01-introduction/sections/02-installing.asc
@@ -48,7 +48,6 @@ On RedHat or another RPM based system, you would use the `rpm -i` command:
 
   $ rpm -i atom.x86_64.rpm
 
-
 ==== Atom from Source
 
 If none of those options works for you or you just want to build Atom from source, you can also do that.
@@ -56,3 +55,19 @@ If none of those options works for you or you just want to build Atom from sourc
 There are detailed and up to date build instructions for Mac, Windows, Linux and FreeBSD at: https://github.com/atom/atom/tree/master/docs/build-instructions
 
 In general, you need Git, a C++ toolchain, and Node to build it. See the repository documentation for detailed instructions.
+
+==== Setting up a Proxy
+
+If you're using a proxy, you can configure https://github.com/atom/apm[apm] (Atom Package Manager) to use it by setting the `https-proxy` config in your `~/.atom/.apmrc` file:
+
+```
+https-proxy = https://9.0.2.1:0
+```
+
+If you are behind a firewall and seeing SSL errors when installing packages, you can disable strict SSL by putting the following in your `~/.atom/.apmrc` file:
+
+```
+strict-ssl = false
+```
+
+You can run `apm config get https-proxy` to verify it has been set correctly, and running `apm config list` lists all custom config settings.


### PR DESCRIPTION
This closes https://github.com/atom/docs/issues/55 by adding the [Behind a firewall](https://github.com/atom/apm#behind-a-firewall) section from the apm README to the "Installing Atom" chapter of the Flight Manual.