### PR TITLE
Flight Manual grammar documentation fixes

### DIFF
--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -15,7 +15,7 @@ This is the Atom welcome screen and gives you a pretty good starting point for h
 First of all, let's get acquainted with some of the terminology we'll be using in this manual.
 
 Buffer::
-  A buffer is the text content of a file in Atom. It's basically the same as a file for most descriptions, but it's the version Atom has in memory. For instance, you can change the text of a buffer and it isn't written to it's associated file until you save it.
+  A buffer is the text content of a file in Atom. It's basically the same as a file for most descriptions, but it's the version Atom has in memory. For instance, you can change the text of a buffer and it isn't written to its associated file until you save it.
 
 Pane::
   A pane is a visual section of Atom. If you look at the welcome screen we just launched, you can see four Panes - the tab bar, the gutter (which has line numbers in it), the status bar at the bottom and finally the text editor.
@@ -123,7 +123,7 @@ This is a great tool if you're used to the terminal or you work from the termina
 
 Editing a file is pretty straightforward. You can click around and scroll with your mouse and type to change the content. There is no special editing mode or key commands.
 
-To save a file you can choose ``File >> Save'' from the menu bar or `cmd-S` to save the file. If you choose ``Save As'' or hit `cmd-shift-S` then you can save the current content in your editor under a different file name. Finally, you can choose `ctl-shift-S` to save all the open files in Atom.
+To save a file you can choose ``File >> Save'' from the menu bar or `cmd-S` to save the file. If you choose ``Save As'' or hit `cmd-shift-S` then you can save the current content in your editor under a different file name. Finally, you can choose `ctrl-shift-S` to save all the open files in Atom.
 
 ==== Opening Directories
 
@@ -143,11 +143,11 @@ You can also hide and show it with `cmd-\` or the `tree-view:toggle` command fro
 [NOTE]
 .Atom Modules
 ====
-Like many parts of Atom, the Tree view is not built directly into the editor, but is it's own standalone package that is simply shipped with Atom by default.
+Like many parts of Atom, the Tree view is not built directly into the editor, but is its own standalone package that is simply shipped with Atom by default.
 
 You can find the source code to the Tree view here: https://github.com/atom/tree-view
 
-This is one of the interesting things about Atom. Many of it's core features are actually just packages implemented the same way you would implement any other functionality. This means that if you don't like the Tree view for example, it's fairly simple to write your own implementation of that functionality and replace it entirely.
+This is one of the interesting things about Atom. Many of its core features are actually just packages implemented the same way you would implement any other functionality. This means that if you don't like the Tree view for example, it's fairly simple to write your own implementation of that functionality and replace it entirely.
 ====
 
 ===== Opening a File in a Project

--- a/book/02-using-atom/1-using-atom.asc
+++ b/book/02-using-atom/1-using-atom.asc
@@ -21,4 +21,4 @@ include::sections/06-customizing.asc[]
 
 At this point you should be something of an Atom master user. You should be able to navigate and manipulate your text and files like a wizard. You should also be able to customize Atom backwards and forwards to make it look and act just how you want it to.
 
-Next we're going to take the next step, which is to look at changing and adding new functionality to the core of Atom itself. We're going to start creating packages for Atom. If you can dream it, you can build it.
+In the next chapter, we're going to kick it up a notch: we'll take a look at changing and adding new functionality to the core of Atom itself. We're going to start creating packages for Atom. If you can dream it, you can build it.

--- a/book/02-using-atom/sections/01-packages-themes.asc
+++ b/book/02-using-atom/sections/01-packages-themes.asc
@@ -3,7 +3,7 @@
 
 First we'll start with the Atom package system. As we mentioned previously, Atom itself is a very basic core of functionality that ships with a number of useful packages that add new features like the https://github.com/atom/tree-view[Tree View] and the https://github.com/atom/settings-view[Settings View].
 
-In fact, there are more than 70 packages that comprise all of the functionality that is available in Atom by default. As some examples, the https://github.com/atom/welcome[Welcome dialog] that you see when you first start it, the https://github.com/atom/spell-check[spell checker], the https://github.com/atom/one-dark-ui[themes] and the https://github.com/atom/fuzzy-finder[fuzzy finder] are all packages that are separately maintained and all use the same APIs that you have access to, as we'll see in great detail in <<_hacking>>.
+In fact, there are more than 70 packages that comprise all of the functionality that is available in Atom by default. For example: the https://github.com/atom/welcome[Welcome dialog] that you see when you first start it, the https://github.com/atom/spell-check[spell checker], the https://github.com/atom/one-dark-ui[themes] and the https://github.com/atom/fuzzy-finder[fuzzy finder] are all packages that are separately maintained and all use the same APIs that you have access to, as we'll see in great detail in <<_hacking>>.
 
 This means that packages can be incredibly powerful and can change everything from the very look and feel of the entire interface to the basic operation of even core functionality.
 
@@ -14,7 +14,7 @@ The packages listed here have been published to https://atom.io/packages[atom.io
 .Package install screen
 image::images/packages.png[Package install screen]
 
-All of the packages will come up with an ``Install'' button. Clicking that will download the package and install it and your editor will now start having this functionality.
+All of the packages will come up with an ``Install'' button. Clicking that will download the package and install it. Your editor will now have the functionality that the package provides.
 
 [[_package_settings]]
 ==== Package Settings
@@ -36,7 +36,7 @@ You can also find and install new themes for Atom from the Settings view. These 
 .Theme search screen
 image::images/themes.png[Theme search screen]
 
-Clicking on the ``Learn More'' button on any of the themes will take you to a profile page for the theme on atom.io where there is nearly always a screenshot for seeing what the theme looks like.
+Clicking on the ``Learn More'' button on any of the themes will take you to a profile page for the theme on atom.io, which usually has a screenshot of the theme. This way you can see what it looks like before installing it.
 
 Clicking on ``Install'' will install the theme and make it available in the Theme dropdowns as we saw in  <<_color_themes>>.
 

--- a/book/02-using-atom/sections/02-text.asc
+++ b/book/02-using-atom/sections/02-text.asc
@@ -3,7 +3,7 @@
 
 While it's pretty easy to move around Atom by clicking with the mouse or using the arrow keys, there are some keybindings that may help you keep your hands on the keyboard and navigate around a little faster.
 
-First of all, Atom ships with many of the basic Emacs keybindings for navigating a document. To go up and down a single character, you can use `ctrl-P` and `ctrl-N`. To go left and right a single character, you can use `ctrl-B` and `ctrl-F`. These are the equivalent of using the arrow keys, though some people prefer to not have to move their hands to where the arrow keys are located on their keyboard.
+First of all, Atom ships with many of the basic Emacs keybindings for navigating a document. To go up and down a single character, you can use `ctrl-P` and `ctrl-N`. To go left and right a single character, you can use `ctrl-B` and `ctrl-F`. These are the equivalent of using the arrow keys, though some people prefer not having to move their hands to where the arrow keys are located on their keyboard.
 
 In addition to single character movement, there are a number of other movement keybindings.
 
@@ -80,7 +80,7 @@ In addition to the cursor movement selection commands, there are also a few comm
 [[_working_with_text]]
 === Editing and Deleting Text
 
-So far we've looked at a number of ways to move around and select regions of a file, so now lets actually change some of that text. Obviously you can type in order to insert characters, but there are also a number of ways to delete and manipulate text that could come in handy.
+So far we've looked at a number of ways to move around and select regions of a file, so now let's actually change some of that text. Obviously you can type in order to insert characters, but there are also a number of ways to delete and manipulate text that could come in handy.
 
 ==== Basic Manipulation
 

--- a/book/02-using-atom/sections/03-interface.asc
+++ b/book/02-using-atom/sections/03-interface.asc
@@ -20,7 +20,7 @@ You can split any editor pane horizontally or vertically by using `cmd-k arrow` 
 .Multiple panes
 image::images/panes.png[panes]
 
-Each pane has it's own ``items'' or files, which are represented by tabs. You can move the files from pane to pane by dragging them with the mouse and dropping them in the pane you want that file to be in.
+Each pane has its own ``items'' or files, which are represented by tabs. You can move the files from pane to pane by dragging them with the mouse and dropping them in the pane you want that file to be in.
 
 To close a pane, close all its editors with `cmd-w`, then press `cmd-w` one more time to close the pane. You can configure panes to auto-close when empty in the Settings view.
 
@@ -29,9 +29,9 @@ To close a pane, close all its editors with `cmd-w`, then press `cmd-w` one more
 
 The ``grammar'' of a buffer is what language Atom thinks that file content is. Types of grammars would be Java or Markdown. We looked at this a bit when we created some snippets in <<_snippets>>.
 
-If you load up a file, Atom does a little work to try to figure out what type of file it is. Largely this is accomplished by looking at it's file extension (`.md` is generally a Markdown file, etc), though sometimes it has to inspect the content a bit to figure it out if it's ambiguous.
+If you load up a file, Atom does a little work to try to figure out what type of file it is. Largely this is accomplished by looking at its file extension (`.md` is generally a Markdown file, etc), though sometimes it has to inspect the content a bit to figure it out if it's ambiguous.
 
-If you load up a file and Atom can't determine a grammar for the file, it will default to 'Plain Text', which is the simplest one. If it does this, if it miscategorizes a file, or if for any reason you wish to change the active grammar of a file, you can pull up the Grammar selector with `ctrl-shift-L`.
+If you load up a file and Atom can't determine a grammar for the file, it will default to 'Plain Text', which is the simplest one. If it does default to 'Plain Text' or miscategorize a file, or if for any reason you wish to change the active grammar of a file, you can pull up the Grammar selector with `ctrl-shift-L`.
 
 .Grammar selector
 image::images/grammar.png[grammar selector]

--- a/book/02-using-atom/sections/04-git-markdown.asc
+++ b/book/02-using-atom/sections/04-git-markdown.asc
@@ -50,11 +50,11 @@ image::images/git-status-bar.png[status bar]
 
 The currently checked out branch name is shown with the number of commits the branch is ahead of or behind its upstream branch.
 
-Also an icon is added if the file is untracked, modified, or ignored. The number of lines added and removed since the file was last committed will be displayed as well.
+An icon is added if the file is untracked, modified, or ignored. The number of lines added and removed since the file was last committed will be displayed as well.
 
 ==== Line diffs
 
-The included https://github.com/atom/git-diff[git-diff] package colorizes the gutter next to lines that have been added, edited, and removed.
+The included https://github.com/atom/git-diff[git-diff] package colorizes the gutter next to lines that have been added, edited, or removed.
 
 .Git line diffs
 image::images/git-lines.png[git line diffs]

--- a/book/02-using-atom/sections/05-writing.asc
+++ b/book/02-using-atom/sections/05-writing.asc
@@ -1,9 +1,9 @@
 [[_atom_markdown]]
 === Writing in Atom
 
-Though it is probably most common to use Atom to write software code, Atom can also be used to write prose quite effectively. Most often this is done in some sort of markup language such as Markdown or Asciidoc (as this manual is written in). Here we'll quickly cover a few of the tools Atom provides for helping you write prose.
+Though it is probably most common to use Atom to write software code, Atom can also be used to write prose quite effectively. Most often this is done in some sort of markup language such as Markdown or Asciidoc (which this manual is written in). Here we'll quickly cover a few of the tools Atom provides for helping you write prose.
 
-Here we'll concentrate on writing in Markdown, but other prose markup languages like Asciidoc have packages that provide similar functionality.
+In these docs, we'll concentrate on writing in Markdown; however, other prose markup languages like Asciidoc have packages that provide similar functionality.
 
 ==== Spell Checking
 


### PR DESCRIPTION
While going through Atom's Flight Manual, I noticed some small grammar mistakes here and there. This PR contains corrections for them.