### PR TITLE
Add sub-section on renaming packages

### DIFF
--- a/book/04-behind-atom/sections/07-maintaining-your-packages.asc
+++ b/book/04-behind-atom/sections/07-maintaining-your-packages.asc
@@ -47,6 +47,11 @@ First, edit the `name` field in your package's `package.json`:
 }
 ```
 
+Then commit your changes:
+```bash
+git commit -am "Rename package"
+```
+
 Then, publish a new version of your package:
 
 ```bash

--- a/book/04-behind-atom/sections/07-maintaining-your-packages.asc
+++ b/book/04-behind-atom/sections/07-maintaining-your-packages.asc
@@ -38,22 +38,10 @@ This will remove your package from the https://atom.io package registry. Anyone 
 
 ==== Rename Your Package
 
-You can rename your package by publishing a new version with the name changed in your package's `package.json`. Requests made to the previous name will be forwarded to the new name.
+If you need to rename your package for any reason, you can do so with one simple command. `apm publish --rename` changes the `name` field in your package's `package.json`, pushes a new commit and tag, and publishes your renamed package. Requests made to the previous name will be forwarded to the new name.
 
-First, edit the `name` field in your package's `package.json`:
-```json
-{
-  "name": "new-name-of-package"
-}
-```
-
-Then commit your changes:
-```bash
-git commit -am "Rename package"
-```
-
-Then, publish a new version of your package:
+WARNING: Once a package name has been used, it cannot be re-used by another package even if the original package is unpublished.
 
 ```bash
-apm publish minor
+apm publish --rename new-package-name
 ```

--- a/book/04-behind-atom/sections/07-maintaining-your-packages.asc
+++ b/book/04-behind-atom/sections/07-maintaining-your-packages.asc
@@ -38,7 +38,7 @@ This will remove your package from the https://atom.io package registry. Anyone 
 
 ==== Rename Your Package
 
-If you need to rename your package for any reason, you can do so with one simple command. `apm publish --rename` changes the `name` field in your package's `package.json`, pushes a new commit and tag, and publishes your renamed package. Requests made to the previous name will be forwarded to the new name.
+If you need to rename your package for any reason, you can do so with one simple command – `apm publish --rename` changes the `name` field in your package's `package.json`, pushes a new commit and tag, and publishes your renamed package. Requests made to the previous name will be forwarded to the new name.
 
 WARNING: Once a package name has been used, it cannot be re-used by another package even if the original package is unpublished.
 

--- a/book/04-behind-atom/sections/07-maintaining-your-packages.asc
+++ b/book/04-behind-atom/sections/07-maintaining-your-packages.asc
@@ -35,3 +35,20 @@ apm unpublish package-name
 ```
 
 This will remove your package from the https://atom.io package registry. Anyone who has already downloaded a copy of your package will still have it and be able to use it, but it will no longer be available for installation by others.
+
+==== Rename Your Package
+
+You can rename your package by publishing a new version with the name changed in your package's `package.json`. Requests made to the previous name will forward to the new name.
+
+First, edit the `name` field in your package's `package.json`:
+```json
+{
+  "name": "new-name-of-package"
+}
+```
+
+Then, publish a new version of your package:
+
+```bash
+apm publish minor
+```

--- a/book/04-behind-atom/sections/07-maintaining-your-packages.asc
+++ b/book/04-behind-atom/sections/07-maintaining-your-packages.asc
@@ -38,7 +38,7 @@ This will remove your package from the https://atom.io package registry. Anyone 
 
 ==== Rename Your Package
 
-You can rename your package by publishing a new version with the name changed in your package's `package.json`. Requests made to the previous name will forward to the new name.
+You can rename your package by publishing a new version with the name changed in your package's `package.json`. Requests made to the previous name will be forwarded to the new name.
 
 First, edit the `name` field in your package's `package.json`:
 ```json


### PR DESCRIPTION
Adapted from https://github.com/atom/atom/blob/master/docs/apm-rest-api.md#renaming-a-package

/cc @atom/issue-triage 