### PR TITLE
Convert book outline to Markdown

### DIFF
--- a/outline.md
+++ b/outline.md
@@ -4,7 +4,7 @@ done.  We'll remove lines from this when each section is completed so we
 only have what it left to do here.
 
 You'll notice in some of the active `book/[section]/sections/` folders
-there are some 'xx-name.asc' files. These are sections of content that
+there are some `xx-name.asc` files. These are sections of content that
 should probably be folded in at some point but we're not sure exactly where
 to put them. They aren't included in any of the main files, so they aren't
 currently rendered. If you want to write something and aren't sure where it
@@ -13,37 +13,35 @@ it into the narrative structure.
 
 Here is the remaining outline:
 
-# Chapter 3
+## Chapter 3: Hacking Atom
 
-* Hacking Atom
-  * Tutorials
-    X Word Count Package (Basic)
-    * Word Count Status Bar (status bar manipulation)
-    * Go To Line Package (simple with feedback and cursor movement)
-    * Open On GitHub - (no UI, just run command)
-    * Snippets - (modify text in a buffer)
-    * Linter - (modify text in a buffer, shell to external command)
-    * Preview Pane (add a panel)
-    * Fuzzy Finder (modal and open file in new tab)
-    * Tree View / Mini-map (add a sidebar panel)
-    * Status Bar (add small panel)
-    * Git-Log / Settings View (standalone UI in tab)
-    * Git-status / Bookmarks (decorate gutter)
-    * Autocomplete / Color picker (in-context UI)
-    * Vim-mode (editor remapping)
-    * Image View (file type rendering handler)
-    * Language (GFM?)
-      * Creating grammars
-      * converting-a-text-mate-bundle.md
-    * Unity UI (UI theme)
-      * converting-a-text-mate-theme.md
-      * theme-variables.md
-      * Shadow DOM
-      - https://atom.io/docs/latest/upgrading/upgrading-your-ui-theme
+* Tutorials
+  * [x] Word Count Package (Basic)
+  * Word Count Status Bar (status bar manipulation)
+  * Go To Line Package (simple with feedback and cursor movement)
+  * Open On GitHub - (no UI, just run command)
+  * Snippets - (modify text in a buffer)
+  * Linter - (modify text in a buffer, shell to external command)
+  * Preview Pane (add a panel)
+  * Fuzzy Finder (modal and open file in new tab)
+  * Tree View / Mini-map (add a sidebar panel)
+  * Status Bar (add small panel)
+  * Git-Log / Settings View (standalone UI in tab)
+  * Git-status / Bookmarks (decorate gutter)
+  * Autocomplete / Color picker (in-context UI)
+  * Vim-mode (editor remapping)
+  * Image View (file type rendering handler)
+  * Language (GFM?)
+    * Creating grammars
+    * converting-a-text-mate-bundle.md
+  * Unity UI (UI theme)
+    * converting-a-text-mate-theme.md
+    * theme-variables.md
+    * Shadow DOM
+    - https://atom.io/docs/latest/upgrading/upgrading-your-ui-theme
 
-# Chapter 4
+## Chapter 4: Behind Atom
 
-* Behind Atom
   * advanced dev tools
     - keybinding resolver
     - timecop
@@ -58,6 +56,7 @@ Here is the remaining outline:
     * don't make a slow package
     * CI for packages (http://blog.atom.io/2014/04/25/ci-for-your-packages.html)
 
+### Include in Chapter 3 or 4
 * Make sure we include (in Ch 3 or Ch4 or both)
   * scopes (https://atom.io/docs/v0.174.0/advanced/scopes-and-scope-descriptors)
   * views / models
@@ -89,37 +88,35 @@ Here is the remaining outline:
   * modal decorations
   * notifications
 
-# Chapter 5
+## Chapter 5: Contributing to Atom
 
-* Contributing to Atom
-  * To packages
-    * Cloning and apm linking
-    * apm install/update
-    * Native modules
-    * Running specs
-    * Link to sending a pull request
-  * To core
-    * Opening issues
-    * Roadmaps
-      - http://blog.atom.io/2014/10/23/public-roadmap.html
-    * Where is the code?
-    * Forum
-    * Building Atom
-    * Technologies it uses
-      * Node
-      * Atom-shell
-      * apm
-      * npm
-    * Coding conventions
-    * Commit conventions
+* To packages
+  * Cloning and apm linking
+  * apm install/update
+  * Native modules
+  * Running specs
+  * Link to sending a pull request
+* To core
+  * Opening issues
+  * Roadmaps
+    - http://blog.atom.io/2014/10/23/public-roadmap.html
+  * Where is the code?
+  * Forum
+  * Building Atom
+  * Technologies it uses
+    * Node
+    * Atom-shell
+    * apm
+    * npm
+  * Coding conventions
+  * Commit conventions
 
-# Chapter 6
+## Chapter 6: Electron
 
-* Electron
-  * developing a new project in electron
-  * https://github.com/atom/electron
+* developing a new project in electron
+* https://github.com/atom/electron
 
-# Chapter 7 / Appendix
+## Chapter 7 / Appendix
 
 * Reference Manual
 * Cookbook snippets


### PR DESCRIPTION
Makes the book outline a little prettier (and lets us use things like TODO lists) :stuck_out_tongue_closed_eyes: 

/cc @atom/issue-triage 