### PR TITLE
Fix link to Package Word Count from The Init File

### DIFF
--- a/book/03-hacking-atom/sections/02-init-file.asc
+++ b/book/03-hacking-atom/sections/02-init-file.asc
@@ -1,7 +1,7 @@
 [[_the_init_file]]
 === The Init File
 
-When Atom finishes loading, it will evaluate `init.coffee` in your `~/.atom` directory, giving you a chance to run CoffeeScript code to make customizations. Code in this file has full access to https://atom.io/docs/api/latest/Atom[Atom's API]. If customizations become extensive, consider creating a package, which we will cover in <<_package_word_count>>.
+When Atom finishes loading, it will evaluate `init.coffee` in your `~/.atom` directory, giving you a chance to run CoffeeScript code to make customizations. Code in this file has full access to https://atom.io/docs/api/latest/Atom[Atom's API]. If customizations become extensive, consider creating a package, which we will cover in https://atom.io/docs/latest/hacking-atom-package-word-count[Package Word Count].
 
 You can open the `init.coffee` file in an editor from the _Atom > Open Your Init Script_ menu. This file can also be named `init.js` and contain JavaScript code.
 


### PR DESCRIPTION
Section [3.2: The Init File](https://atom.io/docs/latest/hacking-atom-the-init-file) includes a link to `Package: Word Count` that didn't work for me; it defaulted back to the main docs page.

(My guess is that Package Word Count content used to be on the same page, and could use the shorthand for finding a section on the same page, `<some-header>`. Since then, it seems to have moved, so I think it needs to use the longer format, `whatever_path[Text to Display]`.)

I've never written asciidoc before and was just passing through the Atom docs, so let me know if there's a better fix for this! :grin: