### PR TITLE
Correct save all opened files key shortcut

### DIFF
--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -123,7 +123,7 @@ This is a great tool if you're used to the terminal or you work from the termina
 
 Editing a file is pretty straightforward. You can click around and scroll with your mouse and type to change the content. There is no special editing mode or key commands.
 
-To save a file you can choose ``File >> Save'' from the menu bar or `cmd-S` to save the file. If you choose ``Save As'' or hit `cmd-shift-S` then you can save the current content in your editor under a different file name. Finally, you can choose `ctrl-shift-S` to save all the open files in Atom.
+To save a file you can choose ``File >> Save'' from the menu bar or `cmd-S` to save the file. If you choose ``Save As'' or hit `cmd-shift-S` then you can save the current content in your editor under a different file name. Finally, you can choose `cmd-alt-S` to save all the open files in Atom.
 
 ==== Opening Directories
 


### PR DESCRIPTION
The keystroke on Mac for command window:save-all should be `alt-cmd-s` instead of `ctrl-shift-S`.