### PR TITLE
Update css selector to ::shadow for .cursor

### DIFF
--- a/book/02-using-atom/sections/06-customizing.asc
+++ b/book/02-using-atom/sections/06-customizing.asc
@@ -17,7 +17,7 @@ For example, to change the color of the cursor, you could add the following rule
 
 [source,css]
 ----
-atom-text-editor.is-focused .cursor {
+atom-text-editor::shadow .cursor {
   border-color: pink;
 }
 ----


### PR DESCRIPTION
Found this while browsing the docs for the first time. The current code example throws a deprecation warning and does nothing.  Enjoying Atom overall though, congratulations :tada:.