### PR TITLE
:abc: Document activationHooks

### DIFF
--- a/book/03-hacking-atom/sections/03-a-basic-package.asc
+++ b/book/03-hacking-atom/sections/03-a-basic-package.asc
@@ -55,6 +55,10 @@ snippets your package needs to load. If not specified, snippets in the _snippets
 - `activationCommands`: an Object identifying commands that trigger your package's activation. The keys are CSS selectors, the values are Arrays of Strings identifying the command.
 The loading of your package is delayed until one of these events is triggered within the associated scope defined by the CSS selector.
 
+- `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered.
+Known hooks are:
+  - `language-package-name:grammar-used` (e.g) `language-javascript:grammar-used`
+
 The `package.json` in the package we've just generated looks like this currently:
 
 ```js
@@ -66,6 +70,25 @@ The `package.json` in the package we've just generated looks like this currently
   "activationCommands": {
     "atom-workspace": "wordcount:toggle"
   },
+  "repository": "https://github.com/atom/wordcount",
+  "license": "MIT",
+  "engines": {
+    "atom": ">0.50.0"
+  },
+  "dependencies": {
+  }
+}
+```
+
+If you wanted to use activationHooks, you might have:
+
+```js
+{
+  "name": "wordcount",
+  "main": "./lib/wordcount",
+  "version": "0.0.0",
+  "description": "A short description of your package",
+  "activationHooks": ["language-javascript:grammar-used", "language-coffee-script:grammar-used"],
   "repository": "https://github.com/atom/wordcount",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This PR documents `activationHooks`, a new key in `package.json`. See also: https://github.com/atom/atom/pull/7638

/cc @thedaniel @nathansobo 