### PR TITLE
Fix typos in Atom Flight Manual chapter 1

### DIFF
--- a/book/01-introduction/1-introduction.asc
+++ b/book/01-introduction/1-introduction.asc
@@ -11,6 +11,6 @@ include::sections/03-basics.asc[]
 
 === Summary
 
-You should now have a basic understanding of what Atom is and what you want to do with it. You should also have it installed on your system and able to use it for the most basic text editing operations.
+You should now have a basic understanding of what Atom is and what you want to do with it. You should also have it installed on your system and be able to use it for the most basic text editing operations.
 
 Now you're ready to start digging into the fun stuff.

--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -167,4 +167,4 @@ Both of those config settings are interpreted as glob patterns as implemented by
 
 You can read more about minimatch here: https://github.com/isaacs/minimatch
 
-This package also will also not show Git ignored files when the `core.excludeVcsIgnoredPaths` is enabled. You can easily toggle this in the Settings view, it's one of the top options.
+This package will also not show Git ignored files when the `core.excludeVcsIgnoredPaths` is enabled. You can easily toggle this in the Settings view, it's one of the top options.


### PR DESCRIPTION
Fix typos in chapter 1 of the Atom Flight Manual in `1-introduction.asc` and `03-basics.asc`.