### PR TITLE
Explain installation of atom and apm on OS X

### DIFF
--- a/book/01-introduction/sections/02-installing.asc
+++ b/book/01-introduction/sections/02-installing.asc
@@ -21,7 +21,19 @@ Here you can download the `atom-mac.zip` file explicitly.
 
 Once you have that file, you can click on it to extract the binary and then drag the new `Atom` application into your ``Applications'' folder.
 
-We also recommend that you run "Window: Install Shell Commands" from the https://atom.io/docs/latest/getting-started-atom-basics#command-palette[Command Palette] so that you can use `atom` and `apm` commands from the terminal.
+[[_installing_atom_on_mac]]
+When you first open Atom, it will try to install the `atom` and `apm` commands for use in the terminal. In some cases, Atom might not be able to install these commands because it needs an administrator password. To check if Atom was able to install the `atom` command, for example, open a terminal window and type `which atom`. If the `atom` command has been installed, you'll see something like this:
+
+  $ which atom
+  /usr/local/bin/atom
+  $
+
+If the `atom` command wasn't installed, the `which` command won't return anything:
+
+  $ which atom
+  $
+
+To install the `atom` and `apm` commands, run "Window: Install Shell Commands" from the https://atom.io/docs/latest/getting-started-atom-basics#command-palette[Command Palette], which will prompt you for an adminstrator password.
 
 ==== Atom on Windows
 

--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -100,7 +100,9 @@ image::images/open-file.png[open file]
 
 This is useful for opening a file that is not contained in the project you're currently in (more on that next), or if you're starting from a new window for some reason.
 
-Another way to open a file in Atom is from the command line. If you're on a Mac, the Atom menu bar will have a command named ``Install Shell Commands'' which installs two new commands in your Terminal: `atom` and `apm`. On Windows and Linux, those two commands will be set up automatically as a part of Atom's <<_installing_atom,installation process>>. You can run the `atom` command with one or more file paths to open up those files in Atom.
+Another way to open a file in Atom is from the command line using the `atom` command. If you're on a Mac, the Atom menu bar has a command named ``Install Shell Commands'' which installs the `atom` and `apm` commands <<_installing_atom_on_mac,if Atom wasn't able to install them itself>>. On Windows and Linux, the `atom` and `apm` commands are installed automatically as a part of Atom's <<_installing_atom,installation process>>.
+
+You can run the `atom` command with one or more file paths to open up those files in Atom.
 
 [script,console]
 ----


### PR DESCRIPTION
Explain how Atom on OS X attempts to install the `atom` and `apm`
commands in `02-installing.asc` and link to this explanation in
`03-basics.asc`. Resolves #96.