### PR TITLE
Fix broken link and spelling error in Flight Manual chapter 1

### DIFF
--- a/book/01-introduction/sections/02-installing.asc
+++ b/book/01-introduction/sections/02-installing.asc
@@ -11,6 +11,7 @@ image::images/linux-downloads.png[Download button]
 
 The buttons should be specific to your platform and easily installable. However, let's go over them here in a bit of detail.
 
+[[_installing_atom_on_mac]]
 ==== Atom on Mac
 
 Atom was originally built for Mac and should be a simple setup process. You can either hit the download button from the atom.io site or you can go to the Atom releases page at:
@@ -21,7 +22,6 @@ Here you can download the `atom-mac.zip` file explicitly.
 
 Once you have that file, you can click on it to extract the binary and then drag the new `Atom` application into your ``Applications'' folder.
 
-[[_installing_atom_on_mac]]
 When you first open Atom, it will try to install the `atom` and `apm` commands for use in the terminal. In some cases, Atom might not be able to install these commands because it needs an administrator password. To check if Atom was able to install the `atom` command, for example, open a terminal window and type `which atom`. If the `atom` command has been installed, you'll see something like this:
 
   $ which atom

--- a/book/01-introduction/sections/02-installing.asc
+++ b/book/01-introduction/sections/02-installing.asc
@@ -33,7 +33,7 @@ If the `atom` command wasn't installed, the `which` command won't return anythin
   $ which atom
   $
 
-To install the `atom` and `apm` commands, run "Window: Install Shell Commands" from the https://atom.io/docs/latest/getting-started-atom-basics#command-palette[Command Palette], which will prompt you for an adminstrator password.
+To install the `atom` and `apm` commands, run "Window: Install Shell Commands" from the https://atom.io/docs/latest/getting-started-atom-basics#command-palette[Command Palette], which will prompt you for an administrator password.
 
 ==== Atom on Windows
 


### PR DESCRIPTION
Move the location of the link target `[[_installing_atom_on_mac]]` in `02-installing.asc`.

The current location of `[[_installing_atom_on_mac]]` works when the book is built locally and viewed as a single web page (`atom.html`) but is broken when the book's HTML is split up into files on https://atom.io/docs/v1.0.2/. The new location in this commit seems to produce the correct HTML that should fix the problem.

Also fix a spelling error.