### PR TITLE
Improve 'opening directories' (multi-platform) wording in docs' introduction

### DIFF
--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -129,7 +129,7 @@ To save a file you can choose ``File >> Save'' from the menu bar or `cmd-s` to s
 
 ==== Opening Directories
 
-Atom doesn't just work with single files though; you will most likely spend most of your time working on projects with multiple files. To open a directory, choose ``File >> Open'' from the menu bar and select a directory from the dialog. You can also add more than one directory to your current Atom window, by choosing ``File >> Add Project Folder...'' from the menu bar or hitting `cmd-shift-O`.
+Atom doesn't just work with single files though; you will most likely spend most of your time working on projects with multiple files. To open a directory, choose the menu item ``File >> Open'' on OS X or ``File >> Open Folder'' on other platforms and select a directory from the dialog. You can also add more than one directory to your current Atom window, by choosing ``File >> Add Project Folder...'' from the menu bar or hitting `cmd-shift-O`.
 
 You can open any number of directories from the command line by passing their paths to the `atom` command line tool. For example, you could run the command `atom ./hopes ./dreams` to open both the `hopes` and the `dreams` directories at the same time.
 


### PR DESCRIPTION
Fix #112