### PR TITLE
Fix typo in link in section 3.2

### DIFF
--- a/book/03-hacking-atom/sections/02-init-file.asc
+++ b/book/03-hacking-atom/sections/02-init-file.asc
@@ -23,4 +23,4 @@ atom.commands.add 'atom-text-editor', 'markdown:paste-as-link', ->
   selection.insertText("[#{selection.getText()}](#{clipboardText})")
 ```
 
-Now, reload Atom and use the <<_command_palette>> to execute the new command by name (i.e., "Markdown: Paste As Link"). And if you'd like to trigger the command via a keyboard shortcut, you can define a <<_customizing_keybindings,keymap for the command>>.
+Now, reload Atom and use the https://github.com/atom/command-palette[command palette] to execute the new command by name (i.e., "Markdown: Paste As Link"). And if you'd like to trigger the command via a keyboard shortcut, you can define a <<_customizing_keybindings,keymap for the command>>.


### PR DESCRIPTION
I fixed the link so it would point to the command palette repo. I wasn't sure if it should link to where i linked it or [here] (https://atom.io/docs/latest/getting-started-atom-basics#command-palette) but i was hoping you guys could give me feedback and i can amend the commit if necessary. Thanks!

Closes #123.