### PR TITLE
Fix some asciidoctor warnings

### DIFF
--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -104,7 +104,7 @@ Another way to open a file in Atom is from the command line using the `atom` com
 
 You can run the `atom` command with one or more file paths to open up those files in Atom.
 
-[script,console]
+[source,shell]
 ----
 $ atom -h
 Atom Editor v0.152.0

--- a/book/03-hacking-atom/sections/06-iconography.asc
+++ b/book/03-hacking-atom/sections/06-iconography.asc
@@ -2,7 +2,7 @@
 
 Atom comes bundled with the https://octicons.github.com/[Octicons] icon set. Use them to add icons to your packages.
 
-===== Usage
+==== Usage
 
 Atom's usage of the Octicons differs just a bit from the https://octicons.github.com/usage/[standard way]. The biggest difference is in the naming of the icon classes. Instead of the `octicon octicon-` prefix, you would use a more generic `icon icon-` prefix.
 
@@ -18,10 +18,10 @@ Or in case you're using http://atom.github.io/space-pen/[SpacePen] it would be:
   @span class: 'icon icon-device-desktop'
 ```
 
-===== Size
+==== Size
 
 Octicons look best with a `font-size` of `16px`. It's already used as the default, so you don't need to worry about it. In case you prefer a different icon size, try to use multiples of 16 (`32px`, `48px` etc.) for the sharpest result. Sizes in between are ok too, but might look a bit blurry for icons with straight lines.
 
-===== Usability
+==== Usability
 
 Although icons can make your UI visually applealing, when used without a text label, it can be hard to guess its meaning. In cases where space for a text label is insufficient, consider adding a https://atom.io/docs/api/latest/TooltipManager[tooltip] that appears on hover. Or a more subtle `title="label"` attribute would already help as well.

--- a/book/A-upgrading/sections/package.asc
+++ b/book/A-upgrading/sections/package.asc
@@ -446,8 +446,8 @@ atom.commands.dispatch editorElement, 'find-and-replace:show'
 A couple large things changed with respect to events:
 
 1. All model events are now exposed as event subscription methods that return https://atom.io/docs/api/latest/Disposable[`Disposable`] objects
-1. The `subscribe()` method is no longer available on `space-pen` `View` objects
-1. An Emitter is now provided from `require 'atom'`
+2. The `subscribe()` method is no longer available on `space-pen` `View` objects
+3. An Emitter is now provided from `require 'atom'`
 
 ===== Consuming Events
 


### PR DESCRIPTION
This fixes up a few warnings that are currently produced by the build process.

Warnings fixed:
```
$ bundle exec rake book:build
Converting to HTML...
asciidoctor: WARNING: book/01-introduction/sections/03-basics.asc: line 108: invalid style for listing block: script
asciidoctor: WARNING: book/03-hacking-atom/sections/06-iconography.asc: line 5: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: book/03-hacking-atom/sections/06-iconography.asc: line 21: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: book/03-hacking-atom/sections/06-iconography.asc: line 25: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: book/A-upgrading/sections/package.asc: line 449: list item index: expected 2, got 1
asciidoctor: WARNING: book/A-upgrading/sections/package.asc: line 450: list item index: expected 3, got 1
```