### PR TITLE
Add note on --profile-startup flag to debugging guide

### DIFF
--- a/book/03-hacking-atom/sections/A01-debugging.asc
+++ b/book/03-hacking-atom/sections/A01-debugging.asc
@@ -116,7 +116,7 @@ image::images/devtools-error.png[devtools error]
 
 If you can reproduce the error, use this approach to get the full stack trace and https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues[report the issue].
 
-==== Diagnose startup performance problems with the Timecop package
+==== Diagnose startup performance problems with the Timecop package and the `--profile-startup` command line flag
 
 If Atom is taking a long time to start, you can use the https://github.com/atom/timecop[Timecop package] to get insight into where Atom spends time while loading.
 
@@ -131,6 +131,14 @@ Timecop displays the following information:
 * Theme loading and activation times
 
 If a specific package has high load or activation times, you might consider disabling it to improve startup speed.
+
+If the time for loading the window looks high, you can create a CPU profile for that period using the `--profile-startup` command line flag when starting Atom:
+
+```shell
+atom --profile-startup .
+```
+
+This will automatically capture a CPU profile as Atom is loading and open the dev tools once Atom loads. You can then switch to the Profiles tab of the dev tools to inspect the "startup" profile and also save it in case you want to share it in an issue.
 
 ==== Diagnose runtime performance problems with the dev tools CPU profiler
 


### PR DESCRIPTION
cc @kevinsawicki for :eyes: because you added this in https://github.com/atom/atom/pull/6543 and I think it would be neat to have it documented here so that we can link to it.