### PR TITLE
Add .travis.yml to fix build break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+install: bundle install
+script: bundle exec rake book:build


### PR DESCRIPTION
It seems atom/docs has been failing on Travis for quite a while. This should fix it.