### PR TITLE
Add sentence on Keybindings Resolver view.

### DIFF
--- a/book/02-using-atom/sections/06-customizing.asc
+++ b/book/02-using-atom/sections/06-customizing.asc
@@ -102,7 +102,7 @@ By default, `~/.atom/keymap.cson` is loaded when Atom is started. It will always
 
 You can open this file in an editor from the _Atom > Open Your Keymap_ menu.
 
-You'll want to know all the commands available to you. Open the Settings panel (`cmd-,`) and select the _Keybindings_ tab. It will show you all the keybindings currently in use.
+You'll want to know all the commands available to you. Open the Settings panel (`cmd-,`) and select the _Keybindings_ tab. It will show you all the keybindings currently in use. If you want to see what selector is taking precedence in a given context, use (`cmd-.`) to open the Keybindings Resolver view. This will tell you if some more specific selector is overriding your customization.
 
 [[_global_configuration_settings]]
 ==== Global Configuration Settings


### PR DESCRIPTION
Because it can be hard to tell what other, more-specific selector is
overriding a user customization. In my case, it was a platform-specific
selector.