### PR TITLE
Add summary chapter 3

### DIFF
--- a/book/03-hacking-atom/1-hacking-atom.asc
+++ b/book/03-hacking-atom/1-hacking-atom.asc
@@ -27,6 +27,8 @@ include::sections/A03-textmate.asc[]
 
 === Summary
 
-( List of topics we covered / appendix? )
+If you finished this chapter, you should be an Atom-hacking master. We've discussed how you should work with CoffeeScript, and how to put it to good use in creating packages. You should also be able to do this in your own created theme now.
 
-Summary.
+Even when something goes wrong, you should be able to debug this easily. But there shouldn't go anything wrong, because you are capable of writing great specs for Atom.
+
+In the next chapter, we’ll go into more of a deep dive on individual internal APIs and systems of Atom, even looking at some Atom source to see how things are really getting done.


### PR DESCRIPTION
Added a short summary to chapter 3, because the [current page](https://atom.io/docs/v1.5.3/hacking-atom-summary) was still empty. This will look a lot better and give more info.